### PR TITLE
[#23] 기능: 안드로이드 상단 status bar 투명화

### DIFF
--- a/android/app/src/main/java/com/example/breadmap/MainActivity.kt
+++ b/android/app/src/main/java/com/example/breadmap/MainActivity.kt
@@ -1,34 +1,82 @@
 package com.example.breadmap
 
+import android.graphics.Color
+import android.util.DisplayMetrics
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
-import com.example.breadmap.Route
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import com.example.breadmap.pages.MainPage
 import com.example.breadmap.pages.LoginPage
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.breadmap.ui.theme.BreadmapTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        var bottomPaddingPx = 0f;
+
+        window.apply {
+            decorView.systemUiVisibility =
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+                addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+                statusBarColor = Color.TRANSPARENT
+            } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                decorView.systemUiVisibility =
+                    decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                decorView.systemUiVisibility =
+                    decorView.systemUiVisibility or
+                        View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+            } else {
+                decorView.systemUiVisibility =
+                    decorView.systemUiVisibility or
+                        View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+            }
+
+            val navResId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+            if (navResId > 0) {
+                bottomPaddingPx = resources.getDimension(navResId)
+            }
+        }
+
         setContent {
-            Main()
+            Main(bottomPaddingPx = bottomPaddingPx)
         }
     }
 
     @Composable
-    private fun Main() {
+    private fun Main(bottomPaddingPx: Float) {
         val navController = rememberNavController()
 
-        NavHost(
-            navController = navController,
-            startDestination = Route.Login.route,
+        val bottomPadding = with(LocalDensity.current) {
+            bottomPaddingPx.toDp()
+        }
+
+        Box(modifier = Modifier
+            .absolutePadding(bottom = bottomPadding)
         ) {
-            composable(Route.Login.route) { LoginPage(navController) }
-            composable(Route.Main.route) { MainPage(navController) }
+            NavHost(
+                navController = navController,
+                startDestination = Route.Login.route,
+            ) {
+                composable(Route.Login.route) { LoginPage(navController) }
+                composable(Route.Main.route) { MainPage(navController) }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/example/breadmap/pages/MainPage.kt
+++ b/android/app/src/main/java/com/example/breadmap/pages/MainPage.kt
@@ -1,5 +1,6 @@
 package com.example.breadmap.pages
 
+import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -14,17 +15,21 @@ fun MainPage(navController: NavController) {
 
 @Composable
 fun WebViewScreen(urlToRender: String) {
-    AndroidView(factory = {
-        WebView(it).apply {
-            settings.javaScriptEnabled = true
-            layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-            )
-            webViewClient = WebViewClient()
-            loadUrl(urlToRender)
-        }
-    }, update = {
-        it.loadUrl(urlToRender)
-    })
+    AndroidView(
+        factory = {
+            WebView(it).apply {
+                settings.javaScriptEnabled = true
+                overScrollMode = View.OVER_SCROLL_NEVER
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                webViewClient = WebViewClient()
+                loadUrl(urlToRender)
+            }
+        },
+        update = {
+            it.loadUrl(urlToRender)
+        },
+    )
 }

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -2,13 +2,13 @@
     <!-- Base application theme. -->
     <style name="Theme.Breadmap" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
+        <item name="colorPrimary">@color/transparent</item>
+        <item name="colorPrimaryVariant">@color/transparent</item>
+        <item name="colorOnPrimary">@color/transparent</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondary">@color/transparent</item>
+        <item name="colorSecondaryVariant">@color/transparent</item>
+        <item name="colorOnSecondary">@color/transparent</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="transparent">#00000000</color>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -2,13 +2,13 @@
     <!-- Base application theme. -->
     <style name="Theme.Breadmap" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorPrimary">@color/transparent</item>
+        <item name="colorPrimaryVariant">@color/transparent</item>
+        <item name="colorOnPrimary">@color/transparent</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondary">@color/transparent</item>
+        <item name="colorSecondaryVariant">@color/transparent</item>
+        <item name="colorOnSecondary">@color/transparent</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->

android에서 상단 status bar를 반투명 / 투명하게 만들어서 지도가 해당 영역까지 차지할 수 있도록 작업

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 -->

closes  #23 <!-- Ex. closes #1 -->

## 추가 구현 필요사항

## 스크린샷 <!-- 빠른 참고 용 -->

상단의 Status bar가 투명으로 적용
![image](https://user-images.githubusercontent.com/19371458/135722143-3b7e91e2-4966-4926-bf0e-929bd43b6a16.png)

