### PR TITLE
[#86] 빵등록 페이지 추가기능 구현

### DIFF
--- a/web/src/components/AddBreadReview/MainAdd.tsx
+++ b/web/src/components/AddBreadReview/MainAdd.tsx
@@ -89,6 +89,7 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
     }
 
     updateBreadsReview(updatedReview);
+    setSingleReview(initialSingleReview);
     setProgress((prev) => prev - 1);
   };
 
@@ -120,15 +121,18 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
   };
 
   const checkEmptySection = (): boolean => {
-    if (singleReview.category === null) return true;
-    else if (singleReview.name === '') return true;
-    else if (singleReview.price === 0) return true;
+    if (breadsReview[progress].category === null) return true;
+    else if (breadsReview[progress].name === '') return true;
+    else if (breadsReview[progress].price === 0) return true;
     else return false;
   };
 
   const nextProgress = () => {
     setIsSubmitted(true);
-    if (checkEmptySection()) return openToast();
+    if (checkEmptySection()) {
+      setCurrentProgress(progress);
+      return openToast();
+    }
 
     setProgress((prev) => prev + 1);
     setCurrentProgress(progress + 1);

--- a/web/src/components/AddBreadReview/MainAdd.tsx
+++ b/web/src/components/AddBreadReview/MainAdd.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { CategoryInfo } from '@/constants/breadCategory';
 import { useCategories } from '@/components/common/CategoryList';
+import { useToast } from '@/components/common/ToastPopup';
 import { Plus } from '@/components/icons';
 import MoreAdd from './MoreAdd';
 import StartAdd from './StartAdd';
@@ -41,6 +42,7 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
     setIsOpenFirst,
   } = useCategories(isMultiSelect);
   const [isSubmitted, setIsSubmitted] = React.useState(false);
+  const { toastStatus, openToast } = useToast();
 
   React.useEffect(() => {
     setIsSubmitted(false);
@@ -126,7 +128,7 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
 
   const nextProgress = () => {
     setIsSubmitted(true);
-    if (checkEmptySection()) return;
+    if (checkEmptySection()) return openToast();
 
     setProgress((prev) => prev + 1);
     setCurrentProgress(progress + 1);
@@ -169,6 +171,7 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
             editScore,
             editContent,
             isSubmitted,
+            toastStatus,
           }}
         />
       )}
@@ -185,6 +188,7 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
             editScore,
             editContent,
             isSubmitted,
+            toastStatus,
           }}
         />
       )}

--- a/web/src/components/AddBreadReview/MainAdd.tsx
+++ b/web/src/components/AddBreadReview/MainAdd.tsx
@@ -40,6 +40,12 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
     onCancelCategory,
     setIsOpenFirst,
   } = useCategories(isMultiSelect);
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsSubmitted(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentProgress]);
 
   React.useEffect(() => {
     setSingleReview(breadsReview[currentProgress]);
@@ -111,7 +117,17 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
     initializeCategories();
   };
 
+  const checkEmptySection = (): boolean => {
+    if (singleReview.category === null) return true;
+    else if (singleReview.name === '') return true;
+    else if (singleReview.price === 0) return true;
+    else return false;
+  };
+
   const nextProgress = () => {
+    setIsSubmitted(true);
+    if (checkEmptySection()) return;
+
     setProgress((prev) => prev + 1);
     setCurrentProgress(progress + 1);
     initializeSingleReview();
@@ -149,8 +165,10 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
             setIsCategoryPage,
             selectedCategory,
             stars,
+            singleReview,
             editScore,
             editContent,
+            isSubmitted,
           }}
         />
       )}
@@ -166,6 +184,7 @@ const MainAdd = ({ breadsReview, updateBreadsReview }: MainAddProps) => {
             deleteSingleReview,
             editScore,
             editContent,
+            isSubmitted,
           }}
         />
       )}

--- a/web/src/components/AddBreadReview/MoreAdd.test.tsx
+++ b/web/src/components/AddBreadReview/MoreAdd.test.tsx
@@ -34,6 +34,7 @@ it('AddBreadReview/MoreAdd', () => {
     deleteSingleReview: jest.fn(),
     editScore: jest.fn(),
     editContent: jest.fn(),
+    isSubmitted: false,
   };
 
   render(<MoreAdd {...props} />);

--- a/web/src/components/AddBreadReview/MoreAdd.test.tsx
+++ b/web/src/components/AddBreadReview/MoreAdd.test.tsx
@@ -35,6 +35,7 @@ it('AddBreadReview/MoreAdd', () => {
     editScore: jest.fn(),
     editContent: jest.fn(),
     isSubmitted: false,
+    toastStatus: false,
   };
 
   render(<MoreAdd {...props} />);

--- a/web/src/components/AddBreadReview/MoreAdd.tsx
+++ b/web/src/components/AddBreadReview/MoreAdd.tsx
@@ -10,10 +10,11 @@ interface MoreAddProps {
   selectedCategory: CategoryInfo[];
   currentProgress: number;
   stars: number[];
-  singleReview: Review | null;
+  singleReview: Review;
   deleteSingleReview: (targetProgress: number) => void;
   editScore: (clickedIndex: number) => void;
   editContent: (e: ChangeEvent<HTMLInputElement>) => void;
+  isSubmitted: boolean;
 }
 
 const MoreAdd = ({
@@ -26,6 +27,7 @@ const MoreAdd = ({
   deleteSingleReview,
   editScore,
   editContent,
+  isSubmitted,
 }: MoreAddProps) => {
   const currentStar = breadsReview[currentProgress]?.star || 0;
 
@@ -67,6 +69,9 @@ const MoreAdd = ({
             </SelectBreadBtn>
             <ArrowDown />
           </SelectArea>
+          {isSubmitted && singleReview.category === null && (
+            <AlertText>빵 종류를 선택해주세요.</AlertText>
+          )}
         </Row>
         <Row>
           <Text isRequired>메뉴명</Text>
@@ -76,6 +81,9 @@ const MoreAdd = ({
             value={breadsReview[currentProgress]?.name || singleReview?.name}
             onChange={(e) => editContent(e)}
           />
+          {isSubmitted && singleReview.name === '' && (
+            <AlertText>메뉴명을 입력해주세요.</AlertText>
+          )}
         </Row>
         <Row>
           <Text isRequired>가격</Text>
@@ -86,6 +94,9 @@ const MoreAdd = ({
             value={renderPrice()}
             onChange={(e) => editContent(e)}
           />
+          {isSubmitted && singleReview.price === 0 && (
+            <AlertText>가격을 입력해주세요.</AlertText>
+          )}
         </Row>
         <Row>
           <Text>별점</Text>
@@ -272,4 +283,11 @@ const EmptyPhoto = styled.div`
   border-radius: 0.5rem;
   background: #eeeeee;
   margin-right: 0.75rem;
+`;
+
+const AlertText = styled.p`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.color.primary500};
+  transition: 1s;
+  transition-delay: 1s;
 `;

--- a/web/src/components/AddBreadReview/MoreAdd.tsx
+++ b/web/src/components/AddBreadReview/MoreAdd.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, useRef } from 'react';
 import styled from '@emotion/styled';
 import { CategoryInfo } from '@/constants/breadCategory';
+import { Toast } from '@/components/common/ToastPopup';
 import { ArrowDown, GrayStar, OrangeStar, Plus } from '@/components/icons';
 import { BreadsReview, Review } from '.';
 
@@ -15,6 +16,7 @@ interface MoreAddProps {
   editScore: (clickedIndex: number) => void;
   editContent: (e: ChangeEvent<HTMLInputElement>) => void;
   isSubmitted: boolean;
+  toastStatus: boolean;
 }
 
 const MoreAdd = ({
@@ -28,6 +30,7 @@ const MoreAdd = ({
   editScore,
   editContent,
   isSubmitted,
+  toastStatus,
 }: MoreAddProps) => {
   const currentStar = breadsReview[currentProgress]?.star || 0;
 
@@ -133,6 +136,7 @@ const MoreAdd = ({
           </Scroll>
         </Row>
       </Content>
+      {toastStatus && <Toast message={'필수정보를 입력해주세요 💪'} />}
     </>
   );
 };

--- a/web/src/components/AddBreadReview/StartAdd.test.tsx
+++ b/web/src/components/AddBreadReview/StartAdd.test.tsx
@@ -15,12 +15,23 @@ it('AddBreadReview/StartAdd', () => {
 
   const fakeStars = [0, 0, 0, 0, 0];
 
+  const fakeReview = {
+    category: fakeCategoryInfo[0],
+    name: '마카롱',
+    price: 3000,
+    text: '넘 맛있어요',
+    star: 5,
+  };
+
   const props = {
     setIsCategoryPage: jest.fn(),
     selectedCategory: fakeCategoryInfo,
     stars: fakeStars,
+    singleReview: fakeReview,
     editScore: jest.fn(),
     editContent: jest.fn(),
+    isSubmitted: false,
+    setIsSubmitted: jest.fn(),
   };
 
   render(<StartAdd {...props} />);

--- a/web/src/components/AddBreadReview/StartAdd.test.tsx
+++ b/web/src/components/AddBreadReview/StartAdd.test.tsx
@@ -31,7 +31,7 @@ it('AddBreadReview/StartAdd', () => {
     editScore: jest.fn(),
     editContent: jest.fn(),
     isSubmitted: false,
-    setIsSubmitted: jest.fn(),
+    toastStatus: false,
   };
 
   render(<StartAdd {...props} />);

--- a/web/src/components/AddBreadReview/StartAdd.tsx
+++ b/web/src/components/AddBreadReview/StartAdd.tsx
@@ -2,26 +2,38 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { CategoryInfo } from '@/constants/breadCategory';
 import { ArrowDown, GrayStar, OrangeStar, Plus } from '@/components/icons';
+import { Review } from '.';
 
 interface StartAddProps {
   setIsCategoryPage: React.Dispatch<React.SetStateAction<boolean>>;
   selectedCategory: CategoryInfo[];
   stars: number[];
+  singleReview: Review;
   editScore: (clickedIndex: number) => void;
   editContent: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  isSubmitted: boolean;
 }
 
 const StartAdd = ({
   setIsCategoryPage,
   selectedCategory,
   stars,
+  singleReview,
   editScore,
   editContent,
+  isSubmitted,
 }: StartAddProps) => {
   const fileRef = React.useRef<HTMLInputElement | null>(null);
   const addPhoto = () => {
     if (!fileRef.current) return;
     fileRef.current.click();
+  };
+
+  const renderPrice = (): number | string => {
+    const price = singleReview?.price;
+    if (price === 0) return '';
+
+    return price as number;
   };
 
   return (
@@ -40,14 +52,21 @@ const StartAdd = ({
             </SelectBreadBtn>
             <ArrowDown />
           </SelectArea>
+          {isSubmitted && selectedCategory.length < 1 && (
+            <AlertText>빵 종류를 선택해주세요.</AlertText>
+          )}
         </Row>
         <Row>
           <Text isRequired>메뉴명</Text>
           <Input
             name="name"
             placeholder="메뉴명을 입력해주세요"
+            value={singleReview?.name}
             onChange={(e) => editContent(e)}
           />
+          {isSubmitted && singleReview.name === '' && (
+            <AlertText>메뉴명을 입력해주세요.</AlertText>
+          )}
         </Row>
         <Row>
           <Text isRequired>가격</Text>
@@ -55,8 +74,12 @@ const StartAdd = ({
             name="price"
             type="number"
             placeholder="원"
+            value={renderPrice()}
             onChange={(e) => editContent(e)}
           />
+          {isSubmitted && singleReview.price === 0 && (
+            <AlertText>가격을 입력해주세요.</AlertText>
+          )}
         </Row>
         <Row>
           <Text>별점</Text>
@@ -228,4 +251,9 @@ const EmptyPhoto = styled.div`
   border-radius: 0.5rem;
   background: #eeeeee;
   margin-right: 0.75rem;
+`;
+
+const AlertText = styled.p`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.color.primary500};
 `;

--- a/web/src/components/AddBreadReview/StartAdd.tsx
+++ b/web/src/components/AddBreadReview/StartAdd.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { CategoryInfo } from '@/constants/breadCategory';
+import { Toast } from '@/components/common/ToastPopup';
 import { ArrowDown, GrayStar, OrangeStar, Plus } from '@/components/icons';
 import { Review } from '.';
 
@@ -12,6 +13,7 @@ interface StartAddProps {
   editScore: (clickedIndex: number) => void;
   editContent: (e: React.ChangeEvent<HTMLInputElement>) => void;
   isSubmitted: boolean;
+  toastStatus: boolean;
 }
 
 const StartAdd = ({
@@ -22,6 +24,7 @@ const StartAdd = ({
   editScore,
   editContent,
   isSubmitted,
+  toastStatus,
 }: StartAddProps) => {
   const fileRef = React.useRef<HTMLInputElement | null>(null);
   const addPhoto = () => {
@@ -114,6 +117,7 @@ const StartAdd = ({
           </Scroll>
         </Row>
       </Content>
+      {toastStatus && <Toast message={'필수정보를 입력해주세요 💪'} />}
     </>
   );
 };

--- a/web/src/components/common/ToastPopup/Toast.tsx
+++ b/web/src/components/common/ToastPopup/Toast.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+interface ToastPopupPros {
+  message: string;
+}
+
+const Toast = ({ message }: ToastPopupPros) => {
+  return <ToastMessage>{message}</ToastMessage>;
+};
+
+export default Toast;
+
+const ToastMessage = styled.div`
+  position: fixed;
+  top: 40px;
+  left: 50%;
+  padding: 10px 12px;
+  transform: translate(-50%, -50%);
+  z-index: 3;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  border-radius: 4px;
+  border: 1px solid #000;
+  font-size: 0.87rem;
+`;

--- a/web/src/components/common/ToastPopup/index.tsx
+++ b/web/src/components/common/ToastPopup/index.tsx
@@ -1,0 +1,2 @@
+export { default as Toast } from './Toast';
+export { default as useToast } from './useToast';

--- a/web/src/components/common/ToastPopup/useToast.ts
+++ b/web/src/components/common/ToastPopup/useToast.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const useToast = (initialState = false) => {
+  const [toastStatus, setToastStatus] = React.useState(initialState);
+
+  const openToast = () => {
+    setToastStatus(true);
+  };
+
+  React.useEffect(() => {
+    if (!toastStatus) return;
+
+    setTimeout(() => {
+      setToastStatus(false);
+    }, 2000);
+  }, [toastStatus]);
+
+  return { toastStatus, openToast };
+};
+
+export default useToast;


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
- [X] toast popup 추가 (common component으로 생성)
- [X]  여러 빵 리뷰 생성후 삭제시, 이전 값 삭제 안되는 버그 수정 (삭제시 singleReview 초기화)
- [X]  빵 추가 버그 수정 (다음빵 추가시 `현재 탭의 빵`이 아닌 `마지막 빵리뷰` 기준으로 빈값 확인)

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 -->
#51 #68 

closes #86 

## 추가 구현 필요사항
- [ ] bottom modal : `사진 추가` / `리뷰 삭제 재확인` / `리뷰 등록 완료`
- [ ] 리뷰 섹션이 바뀌는 영역 구현 필요
- [ ] 사진 미리보기 구현
- [ ] 뒤로가기..? / 닫기 버튼 활성화 필요

## 스크린샷 <!-- 빠른 참고 용 -->

<img src="https://user-images.githubusercontent.com/59910838/140003030-2ac024b8-a317-4ec8-b7e3-baee295ddbf5.png" width="300"/>



