### PR TITLE
[#105] 기능 : 프로필 가보고 싶어요 탭 구현

### DIFF
--- a/web/src/components/UserProfile/MainProfile.tsx
+++ b/web/src/components/UserProfile/MainProfile.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import SettingIcon from '@/components/icons/SettingIcon';
 import styled from '@emotion/styled';
 import { ProfileTitle } from '.';
+import { WishSection, WentSection, ReviewSection } from './TabContents';
 
 interface MainProfileProps {
   pageTitle: ProfileTitle;
@@ -61,7 +62,11 @@ const MainProfile = ({ pageTitle, setPageTitle }: MainProfileProps) => {
             리뷰
           </Tab>
         </Tabs>
-        <Content></Content>
+        <Content>
+          {tab === 'wish' && <WishSection />}
+          {tab === 'went' && <WentSection />}
+          {tab === 'review' && <ReviewSection />}
+        </Content>
       </MyContentSection>
     </MainProfileWrapper>
   );

--- a/web/src/components/UserProfile/MainProfile.tsx
+++ b/web/src/components/UserProfile/MainProfile.tsx
@@ -44,7 +44,7 @@ const MainProfile = ({ pageTitle, setPageTitle }: MainProfileProps) => {
             active={TabType.Wish === tab}
             onClick={() => changeTab(TabType.Wish)}
           >
-            가고 싶어요
+            가보고 싶어요
           </Tab>
           <Tab
             data-tab={TabType.Went}
@@ -149,6 +149,7 @@ const Tab = styled.a<{ active: boolean }>`
   width: 100%;
   padding: 15px 0;
   text-align: center;
+  cursor: pointer;
 
   &::after {
     content: '';

--- a/web/src/components/UserProfile/TabContents/ReviewSection/index.tsx
+++ b/web/src/components/UserProfile/TabContents/ReviewSection/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const ReviewSection = () => {
+  return <Container>리뷰 컨텐츠</Container>;
+};
+
+export default ReviewSection;
+
+const Container = styled.div``;

--- a/web/src/components/UserProfile/TabContents/WentSection/index.tsx
+++ b/web/src/components/UserProfile/TabContents/WentSection/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const WentSection = () => {
+  return <Container>가봤어요 컨텐츠</Container>;
+};
+
+export default WentSection;
+
+const Container = styled.div``;

--- a/web/src/components/UserProfile/TabContents/WishSection/index.tsx
+++ b/web/src/components/UserProfile/TabContents/WishSection/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const WishSection = () => {
+  return <Container>가보고 싶어요 컨텐츠</Container>;
+};
+
+export default WishSection;
+
+const Container = styled.div``;

--- a/web/src/components/UserProfile/TabContents/WishSection/index.tsx
+++ b/web/src/components/UserProfile/TabContents/WishSection/index.tsx
@@ -1,10 +1,40 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { useAtom } from 'jotai';
+import { currentBakeryIdAtom, currentRangeBakeriesAtom } from '@/store/map';
 
-const WishSection = () => {
-  return <Container>가보고 싶어요 컨텐츠</Container>;
+import BakeryInfoCard from '@/components/map/BakeryInfoCard';
+
+const WishSection: React.FC = () => {
+  const [currentBakeryId] = useAtom(currentBakeryIdAtom);
+  const [bakeries] = useAtom(currentRangeBakeriesAtom);
+
+  const currentBakeryEntity = bakeries?.find(
+    (el) => el.bakeryId === currentBakeryId
+  );
+
+  return (
+    <Base>
+      <h1>가보고 싶어요 컨텐츠</h1>
+      {currentBakeryEntity && (
+        <BakeryInfoCard
+          bakeryId={currentBakeryEntity.bakeryId}
+          title={currentBakeryEntity.bakeryName}
+          wentCount={currentBakeryEntity.flagsCount}
+          starAvg={currentBakeryEntity.avgRating}
+          reviewCount={currentBakeryEntity.menuReviewsCount}
+          reviews={currentBakeryEntity.menuReviewList.map(
+            (review) => review.contents
+          )}
+        />
+      )}
+    </Base>
+  );
 };
 
 export default WishSection;
 
-const Container = styled.div``;
+const Base = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/web/src/components/UserProfile/TabContents/index.tsx
+++ b/web/src/components/UserProfile/TabContents/index.tsx
@@ -1,0 +1,3 @@
+export { default as WishSection } from './WishSection';
+export { default as ReviewSection } from './ReviewSection';
+export { default as WentSection } from './WentSection';


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->

- 프로필 메뉴의 가보고 싶어요 탭 구현 (진행중)
- Mock Server API 코드는 해석 후 메인 페이지의 카드 이식 중이나 나타나지 않고 있습니다.
- 제 컴포넌트에서 mock을 import 해야 할까요? 이 부분 2시에 자세히 얘기 해드릴게요!

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 -->

closes #105 <!-- Ex. closes #1 -->

## 추가 구현 필요사항
- 리뷰에는 빵집 카드를 어떤 식으로 출력해야 하는지 시도 중
- 가보고 싶어요, 가봤어요가 필터 말고는 거의 동일 로직 같은데 한 번에 PR 해도 괜찮을지?
- 가보고 싶어요, 가봤어요 데이터를 구분 짓는 flag 표현을 어떻게 할 지 고민


## 스크린샷 <!-- 빠른 참고 용 -->
