### PR TITLE
[#148] QA: 아이폰 상세페이지 탭 하단 border 크기

### DIFF
--- a/web/src/components/bakery/StoreDetailTabs.tsx
+++ b/web/src/components/bakery/StoreDetailTabs.tsx
@@ -95,6 +95,7 @@ const Tabs = styled.ul`
     transition: transform 0.2s ease-in-out;
     transform: translateX(12px);
     width: calc((100% - 24px) / 4);
+    border: 0px;
     border-bottom: 2px solid;
     border-image: linear-gradient(
       to right,


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->

수정해씁니다.
사파리에서는
border-bottom만 넣었는데
왜 border가 3px로 기본으로 들어가는지는 잘 모르겠네요..


## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 -->

closes #148 <!-- Ex. closes #1 -->

## 추가 구현 필요사항

## 스크린샷 <!-- 빠른 참고 용 -->
